### PR TITLE
feat(frontend): live demo de búsqueda de canal en la home

### DIFF
--- a/frontend/src/pages/Auth.jsx
+++ b/frontend/src/pages/Auth.jsx
@@ -33,7 +33,7 @@ const Auth = () => {
         
         login(response.data.user, response.data.accessToken, response.data.refreshToken); 
         alert('¡Inicio de sesión exitoso! Bienvenido, ' + response.data.user.name);
-        navigate('/dashboard');  // antes: '/channels'
+        navigate('/dashboard');  
       } else {
         // REGISTRO
         const response = await authService.register({
@@ -45,7 +45,7 @@ const Auth = () => {
         
         login(response.data.user, response.data.accessToken, response.data.refreshToken); 
         alert('¡Registro exitoso! Bienvenido, ' + response.data.user.name);
-        navigate('/dashboard');  // antes: '/channels'
+        navigate('/dashboard');  
       }
     } catch (err) {
       setError(err.message || 'Error en la autenticación');


### PR DESCRIPTION
Añadido buscador de canales de YouTube en la home que llama al endpoint público  y muestra la información básica del canal como demo. Si el usuario intenta monitorizar el canal desde la home, se le redirige al flujo de registro/login para usar la aplicación real.